### PR TITLE
Fix service step definitions to work with the latest pytest-bdd

### DIFF
--- a/tests/step_defs/test_service_steps.py
+++ b/tests/step_defs/test_service_steps.py
@@ -16,12 +16,12 @@ DUCKDUCKGO_API = 'https://api.duckduckgo.com/'
 
 # Scenarios
 
-scenarios('../features/service.feature', example_converters=dict(phrase=str))
+scenarios('../features/service.feature')
 
 
 # Given Steps
 
-@given('the DuckDuckGo API is queried with "<phrase>"', target_fixture='ddg_response')
+@given(parsers.parse('the DuckDuckGo API is queried with "{phrase}"'), converters={"phrase": str}, target_fixture='ddg_response')
 def ddg_response(phrase):
     params = {'q': phrase, 'format': 'json'}
     response = requests.get(DUCKDUCKGO_API, params=params)
@@ -30,7 +30,7 @@ def ddg_response(phrase):
 
 # Then Steps
 
-@then('the response contains results for "<phrase>"')
+@then(parsers.parse('the response contains results for "{phrase}"'), converters={"phrase": str})
 def ddg_response_contents(ddg_response, phrase):
     # A more comprehensive test would check 'RelatedTopics' for matching phrases
     assert phrase.lower() == ddg_response.json()['Heading'].lower()


### PR DESCRIPTION
Hello,
I fixed service step definitions for them to work with pytest-bdd 5x and 6x.
This pull request fixes issue #10.

