### PR TITLE
Migrate syntax from 4.x.x

### DIFF
--- a/tests/step_defs/test_cucumbers_steps.py
+++ b/tests/step_defs/test_cucumbers_steps.py
@@ -15,28 +15,28 @@ CONVERTERS = {
 }
 
 
-scenarios('../features/cucumbers.feature', example_converters=CONVERTERS)
+scenarios('../features/cucumbers.feature')
 
 
-@given(parsers.cfparse('the basket has "{initial:Number}" cucumbers', extra_types=EXTRA_TYPES), target_fixture='basket')
-@given('the basket has "<initial>" cucumbers', target_fixture='basket')
+# @given(parsers.cfparse('the basket has "{initial:Number}" cucumbers', extra_types=EXTRA_TYPES), target_fixture='basket')
+@given('the basket has "{initial}" cucumbers', target_fixture='basket',converters=CONVERTERS)
 def basket(initial):
     return CucumberBasket(initial_count=initial)
 
 
-@when(parsers.cfparse('"{some:Number}" cucumbers are added to the basket', extra_types=EXTRA_TYPES))
-@when('"<some>" cucumbers are added to the basket')
+# @when(parsers.cfparse('"{some:Number}" cucumbers are added to the basket', extra_types=EXTRA_TYPES))
+@when('"{some}" cucumbers are added to the basket',converters=CONVERTERS)
 def add_cucumbers(basket, some):
     basket.add(some)
 
 
-@when(parsers.cfparse('"{some:Number}" cucumbers are removed from the basket', extra_types=EXTRA_TYPES))
-@when('"<some>" cucumbers are removed from the basket')
+# @when(parsers.cfparse('"{some:Number}" cucumbers are removed from the basket', extra_types=EXTRA_TYPES))
+@when('"{some}" cucumbers are removed from the basket',converters=CONVERTERS)
 def remove_cucumbers(basket, some):
     basket.remove(some)
 
 
-@then(parsers.cfparse('the basket contains "{total:Number}" cucumbers', extra_types=EXTRA_TYPES))
-@then('the basket contains "<total>" cucumbers')
+# @then(parsers.cfparse('the basket contains "{total:Number}" cucumbers', extra_types=EXTRA_TYPES))
+@then('the basket contains "{total}" cucumbers',converters=CONVERTERS)
 def basket_has_total(basket, total):
     assert basket.count == total


### PR DESCRIPTION
As seen in the link below, pytest-bdd has made some changes to the syntax for parameterized scenario outlines
https://pytest-bdd.readthedocs.io/en/latest/index.html?highlight=scenarios#migration-of-your-tests-from-versions-4-x-x
